### PR TITLE
Fix Visualizer Errors

### DIFF
--- a/src/data_object.py
+++ b/src/data_object.py
@@ -902,8 +902,8 @@ class Docker_Command:
         command_type: Docker_Command_Type,
         config_file="",
         launch_mode="",
-        mock_ais="",  # boolean
-        visualizer_mode="",  # boolean
+        mock_ais=False,
+        visualizer_mode=False,
     ):
 
         self.command_type = command_type
@@ -916,7 +916,7 @@ class Docker_Command:
 
         if command_type == Docker_Command_Type.START_CUSTOM:
             header = (
-                """ros2 launch global_launch main.py record:=true log_level:=debug"""
+                """ros2 launch global_launch main_launch.py record:=true log_level:=debug"""
             )
             footer = """2>&1 | tee src/global_launch/voyage_log/combined_log_$( date +%F_%T).txt"""
             self.command = " ".join(
@@ -924,8 +924,8 @@ class Docker_Command:
                     header,
                     f"config:={config_file}",
                     f"mode:={launch_mode}",
-                    f"on_water_mock_ais:={mock_ais}",
-                    f"visualizer_mode:={visualizer_mode}",
+                    f"on_water_mock_ais:={str(mock_ais).lower()}",
+                    f"visualizer_mode:={str(visualizer_mode).lower()}",
                     footer,
                 ]
             )

--- a/src/data_object.py
+++ b/src/data_object.py
@@ -915,9 +915,7 @@ class Docker_Command:
         self.command = command_type.value
 
         if command_type == Docker_Command_Type.START_CUSTOM:
-            header = (
-                """ros2 launch global_launch main_launch.py record:=true log_level:=debug"""
-            )
+            header = """ros2 launch global_launch main_launch.py record:=true log_level:=debug"""
             footer = """2>&1 | tee src/global_launch/voyage_log/combined_log_$( date +%F_%T).txt"""
             self.command = " ".join(
                 [

--- a/src/widgets/CAN_window_UI.py
+++ b/src/widgets/CAN_window_UI.py
@@ -245,7 +245,7 @@ class CANWindowUIMixin:
 
         if (
             action.command_type == Docker_Command_Type.START_VISUAL
-            or action.visualizer_mode == True
+            or action.visualizer_mode
         ):
             self.docker_thread.success.connect(lambda _: self.start_visualizer_tunnel())
 

--- a/src/widgets/CAN_window_UI.py
+++ b/src/widgets/CAN_window_UI.py
@@ -243,8 +243,10 @@ class CANWindowUIMixin:
         self.docker_thread.success.connect(self._on_docker_success)
         self.docker_thread.error.connect(self.show_error)
 
-        # When starting with the visualizer, also forward its port to this machine
-        if action.visualizer_mode == "true":
+        if (
+            action.command_type == Docker_Command_Type.START_VISUAL
+            or action.visualizer_mode == True
+        ):
             self.docker_thread.success.connect(lambda _: self.start_visualizer_tunnel())
 
         self.docker_thread.started.connect(lambda: self.enable_software_controls(False))

--- a/src/widgets/elements.py
+++ b/src/widgets/elements.py
@@ -341,8 +341,8 @@ def init_advanced_soft_panel(self):
                 Docker_Command_Type.START_CUSTOM,
                 launch_mode=self.launch_mode_dropdown.currentText(),
                 config_file=self.config_file_dropdown.currentText(),
-                mock_ais=str(self.mock_ais_checkbox.isChecked()).lower(),
-                visualizer_mode=str(self.visualizer_mode_checkbox.isChecked()).lower(),
+                mock_ais=self.mock_ais_checkbox.isChecked(),
+                visualizer_mode=self.visualizer_mode_checkbox.isChecked(),
             )
         )
     )


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- During OWT 11th July, the visualizer and ros2 launch was not working. This PR fixes the bugs that was produced during the #33. 
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [x] Ran the "Advanced Software Controls" section on the graph side with the following selections
    - [x] Run with mode = production, config = on_water_globals.yaml, check mark the "enable pathfinding visualizer?". Expected output: Visualizer is outputting on the Firefox website, and no data is present as there is no sensor data (gps, etc., is not connected)
    - [x] Run with mode = development, config = on_water_globals.yaml, check mark the "enable pathfinding visualizer?". Expected output: Visualizer is outputting on the Firefox website, and the map and the boat are functioning as expected
    - [x] Run with mode = production, config = on_water_globals.yaml, **no** check mark the "enable pathfinding visualize?r". Expected output: Visualizer is not present.
    - [x]  Run with mode = development, config = on_water_globals.yaml, check mark the "enable pathfinding visualizer?" and check mark "Enable mock ais data?". Expected output: Visualizer is outputting on the Firefox website, and the map and the boat are functioning as expected. `/mock_ais` node is present when running `ros2 node list` in the Docker container
- [x] Run the "start w/ visualizer". Output: Visualizer is outputting on the Firefox website, and no data is present as there is no sensor data (GPS, etc., is not connected)
    

