### PR TITLE
Add the Remaining CAN Frames

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -109,6 +109,22 @@ plrs_path_data_timeout = 30  # 2 * 60 # amt of time (in seconds) before POLARIS 
 latitude_range = 0.1  # in decimal degrees
 longitude_range = 0.1  # in decimal degrees
 
+# ==== AIS Map (chart-style plan view of ship positions) ====
+# NOTE: the map is drawn entirely from vectors (range rings, bearing spokes, ship
+#       markers), so it needs no map tiles
+map_ring_max_count = 6  # max number of range rings drawn around POLARIS
+map_ring_colour = "#8fa0b0"
+map_ring_label_colour = "#61707e"
+map_bearing_interval = 45  # degrees between bearing spokes (must divide 360)
+map_bearing_colour = "#c3ccd4"
+map_compass_colour = "#41505e"
+map_ship_label_colour = "#1c3f66"
+map_ship_vector_colour = "#2f60c0"
+map_polaris_vector_colour = "#c02f2f"
+# Length of the course/speed vector drawn ahead of each ship, in minutes of travel
+# at its current speed (the standard "6 minute vector" of a marine radar display)
+map_vector_minutes = 6
+
 # ==== Heading & PID Tuning ====
 ARROW_TIME_SCALING_ENABLED = True  # If True, how often heading arrows appear is time-based; if False, it is distance-based
 min_time_between_arrows = (

--- a/src/data_object.py
+++ b/src/data_object.py
@@ -13,6 +13,35 @@ import config as cg
 graph_margin = 0.2
 MAX_ANGLE_JUMP = 180
 
+### ---------- Map (AIS plan view) constants & helpers ---------- ###
+METRES_PER_DEG_LAT = 110574  # mean length of a degree of latitude (WGS84)
+METRES_PER_DEG_LON_EQUATOR = 111320  # length of a degree of longitude at the equator
+MIN_ASPECT_RATIO = 0.01  # keeps the map usable if a position near a pole is received
+MAP_FURNITURE_Z = -100  # draw rings/bearings underneath the ships
+RING_SEGMENT_DEG = 5  # angular resolution the range rings are drawn at
+COMPASS_LABEL_MARGIN = 1.08  # compass points sit just outside the outermost ring
+KM_PER_KNOT = 1.852
+
+
+def metres_per_deg_lon(latitude: float) -> float:
+    """Length (in metres) of one degree of longitude at the given latitude"""
+    return METRES_PER_DEG_LON_EQUATOR * math.cos(math.radians(latitude))
+
+
+def nice_ring_spacing(radius_km: float, max_rings: int) -> float:
+    """
+    Return a round spacing (in km) for range rings, such that no more than max_rings
+    rings fit within radius_km - ie. rings every 1, 2 or 5 km, never every 2.77 km
+    """
+    if radius_km <= 0 or max_rings <= 0:
+        return 0
+    smallest = radius_km / max_rings
+    magnitude = 10 ** math.floor(math.log10(smallest))
+    for step in (1, 2, 5):
+        if smallest <= step * magnitude:
+            return step * magnitude
+    return 10 * magnitude
+
 
 def create_label(title, min_width=None, max_height=None):
     if min_width is None:
@@ -192,6 +221,160 @@ class GraphObject:  # struct which keeps together objects needed for a graph
 
     def isVisible(self):
         return self.visible
+
+
+class MapGraphObject(GraphObject):
+    """
+    A GraphObject which presents its (longitude, latitude) data as a chart-style plan
+    view instead of a plain x-y plot:\n
+    - the aspect ratio is locked so a kilometre north and a kilometre east are drawn
+      the same length; without this the picture is stretched east-west by the
+      difference between a degree of latitude and a degree of longitude\n
+    - range rings, bearing spokes and compass points centered on POLARIS give the
+      distance and bearing to every contact at a glance\n
+    NOTE: every element is drawn from vectors - there are no map tiles and no network
+    access of any kind, so the map works offline (as it must on the water)
+    """
+
+    def __init__(self, *args, radius_km=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.centre = (None, None)  # (lon, lat) the map furniture is drawn around
+        # radius of the area the map is expected to cover (used to size the rings)
+        self.radius_km = (
+            radius_km
+            if radius_km is not None
+            else (cg.latitude_range * METRES_PER_DEG_LAT / 1000)
+        )
+        self.ring_curves = []
+        self.range_label = None  # marks the range of the outermost ring
+        self.ring_spacing_km = None  # spacing currently named in the graph title
+        self.bearing_curve = None
+        self.compass_labels = {}
+
+    def initialize(self, custom_y_AxisItem=None):
+        super().initialize(custom_y_AxisItem)
+        # a locked aspect ratio is what turns the plot into a map; the exact ratio
+        # depends on latitude, so it is corrected again as soon as POLARIS reports one
+        self.lock_aspect(self.centre[1] if self.centre[1] is not None else 0)
+        self._init_map_items()
+        if self.centre[0] is not None:
+            self.draw_map()
+
+    def _init_map_items(self):
+        """Create the (empty) range rings, bearing spokes and compass points"""
+        ring_pen = pg.mkPen(cg.map_ring_colour, width=1, style=QtCore.Qt.DashLine)
+        bearing_pen = pg.mkPen(cg.map_bearing_colour, width=1, style=QtCore.Qt.DotLine)
+
+        self.ring_curves = [
+            pg.PlotCurveItem(pen=ring_pen) for _ in range(cg.map_ring_max_count)
+        ]
+        # only the outermost ring is labelled (the ring spacing goes in the title
+        # instead) so the map stays readable when contacts are close together;
+        # the fill masks the bearing spoke running underneath the label
+        self.range_label = pg.TextItem(
+            color=cg.map_ring_label_colour,
+            anchor=(0.5, 0.5),
+            fill=pg.mkBrush(cg.graph_bg),
+        )
+
+        self.bearing_curve = pg.PlotCurveItem(pen=bearing_pen)
+        for bearing, text in ((0, "N"), (90, "E"), (180, "S"), (270, "W")):
+            self.compass_labels[bearing] = pg.TextItem(
+                text, color=cg.map_compass_colour, anchor=(0.5, 0.5)
+            )
+
+        # NOTE: ignoreBounds keeps the map furniture from dragging the view range around
+        for item in (
+            self.ring_curves
+            + [self.range_label, self.bearing_curve]
+            + list(self.compass_labels.values())
+        ):
+            item.setZValue(MAP_FURNITURE_Z)
+            self.graph.addItem(item, ignoreBounds=True)
+
+    def lock_aspect(self, latitude: float) -> None:
+        """
+        Lock the view so that equal distances are drawn equal in both axes.\n
+        pyqtgraph's aspect is (pixels per x unit) / (pixels per y unit), so it is the
+        ratio of the length of a degree of longitude to that of a degree of latitude
+        """
+        ratio = metres_per_deg_lon(latitude) / METRES_PER_DEG_LAT
+        self.graph.getPlotItem().getViewBox().setAspectLocked(
+            True, ratio=max(ratio, MIN_ASPECT_RATIO)
+        )
+
+    def set_centre(self, lon, lat) -> None:
+        """Re-draw the map furniture around the given position (POLARIS)"""
+        if lon is None or lat is None:
+            return
+        self.centre = (lon, lat)
+        if not self.initialized:
+            return  # graph widget does not exist yet - drawn on initialize() instead
+        self.lock_aspect(lat)
+        self.draw_map()
+
+    def name_ring_spacing(self, spacing_km: float) -> None:
+        """Note the range ring spacing in the graph title, so the rings need no labels"""
+        if spacing_km == self.ring_spacing_km:
+            return  # title already says this - nothing to redraw
+        self.ring_spacing_km = spacing_km
+        title = self.dropdown_label
+        if spacing_km > 0:
+            title += f"  (range rings: {spacing_km:g} km)"
+        self.graph.setTitle(
+            title, color=cg.graph_title_style[0], size=cg.graph_title_style[1]
+        )
+
+    def draw_map(self) -> None:
+        """Draw the range rings, bearing spokes and compass points around the centre"""
+        lon, lat = self.centre
+        if lon is None or lat is None or not self.initialized:
+            return
+
+        deg_per_km_lon = 1000 / metres_per_deg_lon(lat)
+        deg_per_km_lat = 1000 / METRES_PER_DEG_LAT
+        spacing_km = nice_ring_spacing(self.radius_km, cg.map_ring_max_count)
+
+        outer_km = 0
+        for i, curve in enumerate(self.ring_curves, start=1):
+            ring_km = spacing_km * i
+            if spacing_km <= 0 or ring_km > self.radius_km:
+                curve.setData([], [])  # unused ring: draw nothing
+                continue
+            outer_km = ring_km
+            d_lon = ring_km * deg_per_km_lon
+            d_lat = ring_km * deg_per_km_lat
+            points = [
+                (
+                    lon + d_lon * math.sin(math.radians(bearing)),
+                    lat + d_lat * math.cos(math.radians(bearing)),
+                )
+                for bearing in range(0, 361, RING_SEGMENT_DEG)
+            ]
+            curve.setData([p[0] for p in points], [p[1] for p in points])
+
+        self.name_ring_spacing(spacing_km)
+        if outer_km == 0:  # no rings fit - fall back to the full map radius
+            outer_km = self.radius_km
+            self.range_label.setText("")
+        else:  # label the outermost ring, due north on the ring itself
+            self.range_label.setText(f"{outer_km:g} km")
+            self.range_label.setPos(lon, lat + outer_km * deg_per_km_lat)
+
+        # bearing spokes, drawn as one curve with NaN gaps between the spokes
+        spoke_x, spoke_y = [], []
+        for bearing in range(0, 360, cg.map_bearing_interval):
+            rad = math.radians(bearing)
+            spoke_x += [lon, lon + outer_km * deg_per_km_lon * math.sin(rad), math.nan]
+            spoke_y += [lat, lat + outer_km * deg_per_km_lat * math.cos(rad), math.nan]
+        self.bearing_curve.setData(spoke_x, spoke_y, connect="finite")
+
+        for bearing, label in self.compass_labels.items():
+            rad = math.radians(bearing)
+            label.setPos(
+                lon + outer_km * COMPASS_LABEL_MARGIN * deg_per_km_lon * math.sin(rad),
+                lat + outer_km * COMPASS_LABEL_MARGIN * deg_per_km_lat * math.cos(rad),
+            )
 
 
 class DataObject:
@@ -755,6 +938,9 @@ class AISObject(DataObject):
         self.dataset_list = []  # a list of dictionaries, where each dictionary contains all data for one frame
         self.dataset = {}  # same as above but is a dictionary containing a bunch of frames instead, of the form MSID: dictionary
         self.log_value_headers = log_value_headers
+        self.ship_labels = {}  # TextItem naming each contact, of the form MMSI: item
+        self.ship_vector_curve = None  # course/speed vector of every contact
+        self.polaris_heading_curve = None  # POLARIS's own heading line
 
     def initialize(self, timestamp=None):
         super().initialize()
@@ -773,6 +959,16 @@ class AISObject(DataObject):
             self.polaris_brush,
             "x",
         )
+        # Course/speed vectors: one curve holding every contact's vector, with NaN
+        # gaps in between, so contacts can come and go without adding/removing items
+        self.ship_vector_curve = pg.PlotCurveItem(
+            pen=pg.mkPen(cg.map_ship_vector_colour, width=cg.linewidth)
+        )
+        self.polaris_heading_curve = pg.PlotCurveItem(
+            pen=pg.mkPen(cg.map_polaris_vector_colour, width=cg.linewidth)
+        )
+        for curve in (self.ship_vector_curve, self.polaris_heading_curve):
+            self.graph_obj.graph.addItem(curve, ignoreBounds=True)
 
     def add_frame(self, x, y, key, data, x_key):
         """x_key is the key for the value containing the x_value"""
@@ -798,6 +994,80 @@ class AISObject(DataObject):
     def clear_data(self):
         self.data.clear()
 
+    def update_line_data(self) -> None:
+        """
+        Re-draw every contact from self.dataset: its position, the vector showing
+        where its course and speed take it over the next cg.map_vector_minutes, and
+        a label naming it.\n
+        NOTE: drawing from self.dataset (keyed by MMSI) rather than self.data (keyed
+        by longitude) means two ships sharing a longitude are both drawn
+        """
+        if self.line is None:
+            return
+
+        lons, lats = [], []
+        vector_x, vector_y = [], []
+        for mmsi, frame in self.dataset.items():
+            lon = frame[AIS_Attributes.LONGITUDE]
+            lat = frame[AIS_Attributes.LATITUDE]
+            if lon is None or lat is None:
+                continue
+            lons.append(lon)
+            lats.append(lat)
+
+            end = self.course_vector_end(frame)
+            if end is not None:  # NaN gap separates this vector from the next one
+                vector_x += [lon, end[0], math.nan]
+                vector_y += [lat, end[1], math.nan]
+
+            self.update_ship_label(mmsi, frame, lon, lat)
+
+        self.line.setData(lons, lats)
+        if self.ship_vector_curve is not None:
+            self.ship_vector_curve.setData(vector_x, vector_y, connect="finite")
+        self.remove_stale_ship_labels()
+
+    def course_vector_end(self, frame):
+        """
+        Return the (lon, lat) a contact reaches after cg.map_vector_minutes on its
+        current course & speed, or None if either is unavailable
+        """
+        cog = frame[AIS_Attributes.COG]
+        sog = frame[AIS_Attributes.SOG]
+        lon = frame[AIS_Attributes.LONGITUDE]
+        lat = frame[AIS_Attributes.LATITUDE]
+        if cog is None or not sog or lon is None or lat is None:
+            return None
+
+        distance_km = sog * KM_PER_KNOT * (cg.map_vector_minutes / 60)
+        rad = math.radians(cog)  # COG is in degrees, 0 is north and increasing CW
+        return (
+            lon + (distance_km * 1000 / metres_per_deg_lon(lat)) * math.sin(rad),
+            lat + (distance_km * 1000 / METRES_PER_DEG_LAT) * math.cos(rad),
+        )
+
+    def update_ship_label(self, mmsi, frame, lon, lat) -> None:
+        """Create (if needed) and position the label naming a single contact"""
+        if mmsi not in self.ship_labels:
+            label = pg.TextItem(
+                color=cg.map_ship_label_colour, anchor=(-0.1, 1.1)
+            )  # anchored so the text sits just above & right of the contact
+            self.ship_labels[mmsi] = label
+            self.graph_obj.graph.addItem(label, ignoreBounds=True)
+
+        text = str(frame[AIS_Attributes.SID])
+        sog = frame[AIS_Attributes.SOG]
+        if sog is not None:
+            text += f"\n{sog} kn"
+        self.ship_labels[mmsi].setText(text)
+        self.ship_labels[mmsi].setPos(lon, lat)
+
+    def remove_stale_ship_labels(self) -> None:
+        """Drop the labels of contacts which are no longer in the dataset"""
+        for mmsi in list(self.ship_labels.keys()):
+            if mmsi not in self.dataset:
+                self.graph_obj.graph.removeItem(self.ship_labels.pop(mmsi))
+
     def update_range(self, x_min=None, x_max=None, y_min=None, y_max=None):
         """
         Modify the range of the x and y axes of the graph object belonging to this object.
@@ -819,7 +1089,10 @@ class AISObject(DataObject):
             ):  # if data has not been updated for long enough: remove dp
                 points_to_delete.append(key)
         for key in points_to_delete:
-            self.remove_datapoint(self.dataset[key][AIS_Attributes.LONGITUDE])
+            # NOTE: the check is needed because self.data is keyed by longitude, so a
+            # contact's point may already have been overwritten by another contact
+            if self.dataset[key][AIS_Attributes.LONGITUDE] in self.data:
+                self.remove_datapoint(self.dataset[key][AIS_Attributes.LONGITUDE])
             del self.dataset[key]
         if self.graph_obj and self.graph_obj.graph.isVisible():
             self.update_line_data()
@@ -867,16 +1140,39 @@ class AISObject(DataObject):
 
         return
 
-    def update_polaris_pos(self, lon, lat):
+    def update_polaris_pos(self, lon, lat, heading=None):
+        """
+        Move POLARIS (and with it the map centred on POLARIS) to the given position.\n
+        heading (in degrees, 0 is north and increasing CW) is optional; when given, a
+        heading line is drawn from POLARIS out to the edge of the map
+        """
         if lon is None or lat is None:
             print(
                 "ERR - update_polaris_pos(): POLARIS lon or lat is None, its position cannot be graphed"
             )
             return  # if either is None, can't graph position - just return
+        self.polaris_pos = (lon, lat)
+        self.graph_obj.set_centre(lon, lat)  # re-centre the range rings & bearings
         if self.graph_obj.isVisible():
             self.polaris_line.setData([lon], [lat])
+        self.update_polaris_heading(lon, lat, heading)
         # print("polaris_pos updated!")
         # print("self.polaris_line = (", self.polaris_line.xData, ", ", self.polaris_line.yData, ")")
+
+    def update_polaris_heading(self, lon, lat, heading) -> None:
+        """Draw POLARIS's heading line, out to the edge of the mapped area"""
+        if self.polaris_heading_curve is None:
+            return
+        if heading is None:
+            self.polaris_heading_curve.setData([], [])
+            return
+
+        rad = math.radians(heading)
+        length_km = self.graph_obj.radius_km
+        self.polaris_heading_curve.setData(
+            [lon, lon + (length_km * 1000 / metres_per_deg_lon(lat)) * math.sin(rad)],
+            [lat, lat + (length_km * 1000 / METRES_PER_DEG_LAT) * math.cos(rad)],
+        )
 
 
 # Docker Command classes

--- a/src/utils.py
+++ b/src/utils.py
@@ -75,6 +75,11 @@ def val(raw_bytes, s, e, div) -> float:
     return int.from_bytes(raw_bytes[s:e], "little") / div
 
 
+def signed_val(raw_bytes, s, e, div) -> float:
+    """Same as val(), but for two's complement (signed) fields"""
+    return int.from_bytes(raw_bytes[s:e], "little", signed=True) / div
+
+
 def convert_float_to_binary32hex(val: float) -> str:
     """
     Return a 8-character lowercase hex string in big endian byte order
@@ -157,6 +162,61 @@ def parse_0x204_frame(data_hex):
         derivative_obj.name: val(12, 14, 1.0) - cg.derivative_offset,
         spd_over_gnd_obj.name: val(14, 16, 1000.0),
     }
+
+
+def parse_0x002_frame(data_hex):
+    raw_bytes = bytes.fromhex(data_hex)
+    if len(raw_bytes) != 4:
+        raise ValueError("Incorrect data length (num bytes): ID 0x002")
+
+    return {  # angle is positive by the right hand rule with vector upwards
+        set_trimtab_obj.name: val(raw_bytes, 0, 4, 1000.0) - 90,
+    }
+
+
+POWER_OFF_VALUE = 0xF  # the only value the POWER_OFF (0x003) frame ever takes
+
+
+def parse_0x003_frame(data_hex) -> int:
+    """
+    Returns the raw POWER_OFF value; per the CAN frame documentation this frame only
+    ever takes the value 0xF, meaning power is cut in 15-30 seconds
+    """
+    raw_bytes = bytes.fromhex(data_hex)
+    if len(raw_bytes) != 1:
+        raise ValueError("Incorrect data length (num bytes): ID 0x003")
+
+    return raw_bytes[0]
+
+
+def parse_0x030_frame(data_hex):
+    raw_bytes = bytes.fromhex(data_hex)
+    if len(raw_bytes) != 8:
+        raise ValueError("Incorrect data length (num bytes): ID 0x030")
+
+    parsed = {
+        bms_volt_obj.name: val(raw_bytes, 0, 4, 100.0),
+        # NOTE: current is signed - negative for charging, positive for discharging
+        bms_curr_obj.name: signed_val(raw_bytes, 4, 8, 100.0),
+    }
+
+    range_check(bms_volt_obj.name, parsed[bms_volt_obj.name], 0)
+
+    return parsed
+
+
+def parse_0x050_frame(data_hex):
+    raw_bytes = bytes.fromhex(data_hex)
+    if len(raw_bytes) != 4:
+        raise ValueError("Incorrect data length (num bytes): ID 0x050")
+
+    parsed = {  # true heading (from the e-compass) in degrees, 0 is north and increasing CW
+        rudr_heading_obj.name: val(raw_bytes, 0, 4, 1000.0),
+    }
+
+    range_check(rudr_heading_obj.name, parsed[rudr_heading_obj.name], 0, 360)
+
+    return parsed
 
 
 def actual_rudder_parsing_fn(parsed_dict):
@@ -471,13 +531,22 @@ pdb_title_text = "PDB Status: "
 rudr_title_text = "RUDR Status: "
 sail_title_text = "SAIL Status: "
 sense_title_text = "SENSE Status: "
+main_title_text = "MAIN Status: "
 
 pdb_hb_module = HeartbeatModule(pdb_title_text)
 rudr_hb_module = HeartbeatModule(rudr_title_text)
 sail_hb_module = HeartbeatModule(sail_title_text)
 sense_hb_module = HeartbeatModule(sense_title_text)
+# NOTE: MAIN_HEARTBEAT is addressed to the PDB, but the GUI sees it on the bus as well
+main_hb_module = HeartbeatModule(main_title_text)
 
-heartbeat_modules = [pdb_hb_module, sail_hb_module, rudr_hb_module, sense_hb_module]
+heartbeat_modules = [
+    pdb_hb_module,
+    sail_hb_module,
+    rudr_hb_module,
+    sense_hb_module,
+    main_hb_module,
+]
 
 ### ---------- Data Objects ---------- ###
 # NOTE: If multiple data objects take data from the same frame, the parsing function function for all of them is None
@@ -530,6 +599,20 @@ mppt_ss_obj = DataObject(
     "MPPT_curr_sail_star", 2, "A", None, line_colour="y", graph=mppt_current_graph_obj
 )
 
+# Battery voltage & current (from BMS frame 0x030)
+bms_volt_graph_obj = GraphObject(
+    "BMS Battery Voltage", cg.graph_y, "V", cg.graph_y_units, 0, 20
+)
+bms_volt_obj = DataObject(
+    "BMS_voltage", 2, "V", None, line_colour="r", graph=bms_volt_graph_obj
+)
+bms_curr_graph_obj = GraphObject(
+    "BMS Battery Current", cg.graph_y, "A", cg.graph_y_units, -20, 20
+)
+bms_curr_obj = DataObject(  # negative when charging, positive when discharging
+    "BMS_current", 2, "A", None, line_colour="b", graph=bms_curr_graph_obj
+)
+
 # Rudder angles (set & actual)
 rudder_graph = GraphObject("Rudder Angles", cg.graph_y, "°", cg.graph_y_units, -90, 90)
 actual_rudder_obj = DataObject(
@@ -539,6 +622,14 @@ set_rudder_obj = DataObject(
     "Set_rdr_deg", 2, "°", None, line_dashed=True, line_colour="b", graph=rudder_graph
 )  # NOTE: graph parsing function changed to None here
 
+# Trim tab angle commanded by the mainframe (from frame 0x002)
+trimtab_graph_obj = GraphObject(
+    "Trim Tab Angle", cg.graph_y, "°", cg.graph_y_units, -90, 90
+)
+set_trimtab_obj = DataObject(
+    "Set_trimtab_deg", 2, "°", None, line_colour="m", graph=trimtab_graph_obj
+)
+
 # Speed over ground (from debug frame 0x204)
 spd_over_gnd_graph_obj = GraphObject(
     "Speed Over Ground", cg.graph_y, "km/h", cg.graph_y_units, 0, 20
@@ -547,9 +638,9 @@ spd_over_gnd_obj = DataObject(
     "Speed_over_gnd", 3, "km/h", None, line_colour="brown", graph=spd_over_gnd_graph_obj
 )
 
-# Headings (IMU & Desired)
+# Headings (IMU, Desired & True)
 headings_graph_obj = GraphObject(
-    "IMU & Desired Headings", cg.graph_y, "°", cg.graph_y_units, 0, 360
+    "IMU, Desired & True Headings", cg.graph_y, "°", cg.graph_y_units, 0, 360
 )
 # imu_heading_obj = DataObject("IMU_heading", 3, "°", None, line_colour="r", graph=headings_graph_obj)
 # desired_heading_obj = DataObject("Desired_heading", 3, "°", None, line_dashed=True, line_colour="b", graph=headings_graph_obj)
@@ -567,6 +658,11 @@ desired_heading_obj = DesiredHeadingObject(
     graph=headings_graph_obj,
     imu_heading_ref_obj=imu_heading_obj,
     interval=cg.manual_input_obj_update_interval,
+)
+# True heading from the rudder board's e-compass (frame 0x050); the IMU heading above
+# comes from the 0x204 debug frame, so the two are plotted together to be compared
+rudr_heading_obj = IMUHeadingObject(
+    "Rudr_true_heading", 3, "°", None, line_colour="g", graph=headings_graph_obj
 )
 
 # IMU roll & pitch
@@ -727,6 +823,15 @@ rudder_objs = [  # all objects with data from 0x204 frame (rudder -> mainframe)
     derivative_obj,
 ]
 
+# all objects with data from 0x050 frame (rudder -> mainframe)
+rudr_objs = [rudr_heading_obj]
+
+# all objects with data from 0x030 frame (pdb -> mainframe)
+bms_objs = [bms_volt_obj, bms_curr_obj]
+
+# all objects with data from 0x002 frame (mainframe -> sail)
+trimtab_objs = [set_trimtab_obj]
+
 data_objs = [pH_obj, temp_sensor_obj, sal_obj]
 gps_objs = [gps_lat_obj, gps_lon_obj, pid_obj]  # pid_y_obj, pid_x_obj]
 
@@ -739,8 +844,11 @@ data_objs = (
     + data_wind_objs
     + sail_wind_objs
     + rudder_objs
+    + rudr_objs
     + [desired_heading_obj]
+    + trimtab_objs
     + pdb_objs
+    + bms_objs
 )
 
 all_objs = data_objs.copy()
@@ -756,7 +864,10 @@ graph_objs = [
     pdb_temp_graph_obj,
     pdb_volt_graph_obj,
     mppt_current_graph_obj,
+    bms_volt_graph_obj,
+    bms_curr_graph_obj,
     rudder_graph,
+    trimtab_graph_obj,
     spd_over_gnd_graph_obj,
     headings_graph_obj,
     imu_roll_pitch_graph_obj,

--- a/src/utils.py
+++ b/src/utils.py
@@ -13,6 +13,7 @@ from data_object import (
     DesiredHeadingObject,
     GraphObject,
     IMUHeadingObject,
+    MapGraphObject,
     PIDObject,
     ais_attributes,
 )
@@ -760,7 +761,9 @@ polaris_brush = mkBrush(color="r")
 # other_pen = pg.mkPen(color='b', width=1)
 other_brush = mkBrush(color="b")
 
-position_graph_obj = GraphObject(
+# NOTE: a MapGraphObject rather than a plain GraphObject, so ship positions are drawn
+#       to scale on a chart-style plan view (offline - no map tiles are involved)
+position_graph_obj = MapGraphObject(
     "Latitude", "Longitude", "DD", "DD", -90, 90, "Ship Positions"
 )  # note: this graph's x_range should definitely not be updated with the rest
 ais_obj = AISObject(

--- a/src/widgets/CAN_window_update.py
+++ b/src/widgets/CAN_window_update.py
@@ -26,6 +26,7 @@ from utils import (
     gps_lon_obj,
     gps_objs,
     heartbeat_modules,
+    imu_heading_obj,
     main_hb_module,
     manual_input_objs,
     parse_0x001_frame,
@@ -45,6 +46,7 @@ from utils import (
     POWER_OFF_VALUE,
     rudder_objs,
     rudr_hb_module,
+    rudr_heading_obj,
     rudr_objs,
     sail_hb_module,
     sail_wind_objs,
@@ -215,7 +217,11 @@ class CANWindowUpdateMixin:
                                 if ais_obj.graph_obj.isVisible():  # graph POLARIS's current position if graph is visible
                                     lon = gps_lon_obj.get_current()[1]
                                     lat = gps_lat_obj.get_current()[1]
-                                    ais_obj.update_polaris_pos(lon, lat)
+                                    # prefer the e-compass true heading (0x050) over the IMU heading (debug frame 0x204)
+                                    heading = rudr_heading_obj.get_current()[1]
+                                    if heading is None:
+                                        heading = imu_heading_obj.get_current()[1]
+                                    ais_obj.update_polaris_pos(lon, lat, heading)
                                     ais_obj.update_range(
                                         lon - longitude_range,
                                         lon + longitude_range,

--- a/src/widgets/CAN_window_update.py
+++ b/src/widgets/CAN_window_update.py
@@ -18,6 +18,7 @@ from utils import (
     AIS_Attributes,
     ais_obj,
     all_objs,
+    bms_objs,
     data_objs,
     data_wind_objs,
     desired_heading_obj,
@@ -25,8 +26,13 @@ from utils import (
     gps_lon_obj,
     gps_objs,
     heartbeat_modules,
+    main_hb_module,
     manual_input_objs,
     parse_0x001_frame,
+    parse_0x002_frame,
+    parse_0x003_frame,
+    parse_0x030_frame,
+    parse_0x050_frame,
     parse_0x060_frame,
     parse_0x070_frame,
     parse_0x204_frame,
@@ -36,14 +42,17 @@ from utils import (
     pdb_hb_module,
     pdb_objs,
     pH_obj,
+    POWER_OFF_VALUE,
     rudder_objs,
     rudr_hb_module,
+    rudr_objs,
     sail_hb_module,
     sail_wind_objs,
     sal_obj,
     sense_hb_module,
     set_rudder_obj,
     temp_sensor_obj,
+    trimtab_objs,
 )
 
 
@@ -96,7 +105,44 @@ class CANWindowUpdateMixin:
                             pass
 
                         case "002":  # Sent frame to trim tab
-                            pass
+                            try:
+                                raw_data = line.split("]")[-1].strip().split()
+                                parsed = parse_0x002_frame("".join(raw_data))
+                                for obj in trimtab_objs:
+                                    obj.parse_frame(current_time, None, parsed)
+                                    obj.update_label()
+                            except Exception as e:
+                                self.output_display.append(
+                                    f"[PARSE ERROR 0x002] {str(e)}"
+                                )
+
+                        case "003":  # Power off frame
+                            try:
+                                raw_data = line.split("]")[-1].strip().split()
+                                parsed = parse_0x003_frame("".join(raw_data))
+                                if parsed == POWER_OFF_VALUE:
+                                    msg = "[POWER OFF] PDB is cutting power in 15-30 seconds!"
+                                else:
+                                    msg = f"[POWER OFF] Unexpected value received: {hex(parsed)}"
+                                print(msg)
+                                self.output_display.append(msg)
+                            except Exception as e:
+                                self.output_display.append(
+                                    f"[PARSE ERROR 0x003] {str(e)}"
+                                )
+
+                        case "030":  # BMS data frame (battery voltage & current)
+                            try:
+                                raw_data = line.split("]")[-1].strip().split()
+                                parsed = parse_0x030_frame("".join(raw_data))
+                                for obj in bms_objs:
+                                    obj.parse_frame(current_time, None, parsed)
+                                    obj.update_label()
+                            except Exception as e:
+                                self.output_display.append(
+                                    f"[PARSE ERROR 0x030] {str(e)}"
+                                )
+
                         case "040":  # Sail_Wind frame
                             try:
                                 raw_data = line.split("]")[-1].strip().split()
@@ -145,6 +191,17 @@ class CANWindowUpdateMixin:
                             except Exception as e:
                                 self.output_display.append(
                                     f"[PARSE ERROR 0x060] {str(e)}"
+                                )
+                        case "050":  # Rudder data frame (true heading from e-compass)
+                            try:
+                                raw_data = line.split("]")[-1].strip().split()
+                                parsed = parse_0x050_frame("".join(raw_data))
+                                for obj in rudr_objs:
+                                    obj.parse_frame(current_time, None, parsed)
+                                    obj.update_label()
+                            except Exception as e:
+                                self.output_display.append(
+                                    f"[PARSE ERROR 0x050] {str(e)}"
                                 )
 
                         case "070":  # GPS frame
@@ -206,6 +263,8 @@ class CANWindowUpdateMixin:
                             sail_hb_module.set_alive(current_time)
                         case "133":
                             sense_hb_module.set_alive(current_time)
+                        case "134":  # MAIN Heartbeat frame
+                            main_hb_module.set_alive(current_time)
 
                         case "204":  # Handle 0x204 frame (actual rudder angle)
                             try:


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
<!-- Replace _issue_ with the issue number that this PR resolves, or delete the line and add this PR to the Software project if there is no related issue. -->
- I have added the remaining CAN frames that we need for our mock CAN transmitter testing to our software team. 
- The most critical logging is the `RUDDER_DATA_FRAME` that has a CAN ID of `0x204`.
<!-- Describe what was done in this PR if there is no related issue, or the related issue's description is not sufficient. -->


### Verification
<!-- List the steps that were taken to verify that the changes introduced by this PR function as desired and without side effects. -->
- [ ] Polaris GUI does not crash
- [ ] Polaris GUI stores the rudder and other key can messages in the logs correctly


