### PR TITLE
add `stop_can_comms` checkbox 

### DIFF
--- a/src/data_object.py
+++ b/src/data_object.py
@@ -906,6 +906,7 @@ class Docker_Command:
         launch_mode="",
         mock_ais=False,
         visualizer_mode=False,
+        disable_CAN_comms=False, # aka manual_mode
     ):
 
         self.command_type = command_type
@@ -913,10 +914,12 @@ class Docker_Command:
         self.launch_mode = launch_mode
         self.mock_ais = mock_ais
         self.visualizer_mode = visualizer_mode
+        self.disable_CAN_comms = disable_CAN_comms
 
         self.command = command_type.value
 
         if command_type == Docker_Command_Type.START_CUSTOM:
+                           
             header = """ros2 launch global_launch main_launch.py record:=true log_level:=debug"""
             footer = """2>&1 | tee src/global_launch/voyage_log/combined_log_$( date +%F_%T).txt"""
             self.command = " ".join(
@@ -926,6 +929,7 @@ class Docker_Command:
                     f"mode:={launch_mode}",
                     f"on_water_mock_ais:={str(mock_ais).lower()}",
                     f"visualizer_mode:={str(visualizer_mode).lower()}",
+                    f"manual_mode:={str(disable_CAN_comms).lower()}",
                     footer,
                 ]
             )

--- a/src/widgets/elements.py
+++ b/src/widgets/elements.py
@@ -296,7 +296,7 @@ def init_advanced_soft_panel(self):
     config_grid = QGridLayout()
     grid_widget = QWidget()
     grid_widget.setLayout(config_grid)
-    grid_widget.setMaximumWidth(500)
+    grid_widget.setMaximumWidth(750)
     config_grid.setContentsMargins(0, 0, 0, 0)
 
     # dropdowns
@@ -326,11 +326,13 @@ def init_advanced_soft_panel(self):
     # checkboxes
     self.mock_ais_checkbox = QCheckBox("Enable mock AIS data?")
     self.visualizer_mode_checkbox = QCheckBox("Enable pathfinding visualizer?")
+    self.disable_CAN_comms_checkbox = QCheckBox("Disable CAN communication on startup?")
 
     config_grid.addLayout(launch_mode_layout, 0, 0, alignment=Qt.AlignLeft)
     config_grid.addLayout(config_file_layout, 1, 0, alignment=Qt.AlignLeft)
     config_grid.addWidget(self.mock_ais_checkbox, 0, 1)
     config_grid.addWidget(self.visualizer_mode_checkbox, 1, 1)
+    config_grid.addWidget(self.disable_CAN_comms_checkbox, 0, 2)
 
     config_grid.setColumnStretch(0, 0)
     config_grid.setColumnStretch(1, 0)
@@ -345,6 +347,7 @@ def init_advanced_soft_panel(self):
                 config_file=self.config_file_dropdown.currentText(),
                 mock_ais=self.mock_ais_checkbox.isChecked(),
                 visualizer_mode=self.visualizer_mode_checkbox.isChecked(),
+                disable_CAN_comms=self.disable_CAN_comms_checkbox.isChecked(),
             )
         )
     )


### PR DESCRIPTION
<!-- Remember to add the relevant reviewers, assignees, and labels, and create this PR as a draft if it is a work in progress. -->

### Description
- See the sailbot_workspace PR for more details. https://github.com/UBCSailbot/sailbot_workspace/pull/1059
- added another checkbox to the Advanced Software controls panel. 
- Defaults to `manual_mode:=false` which enables CAN communications. 


### Verification
- `Custom Launch` button generates the full ros2 launch command correctly. 
